### PR TITLE
Update Ingest-Release-SOP.md

### DIFF
--- a/docs/Ingest-Release-SOP.md
+++ b/docs/Ingest-Release-SOP.md
@@ -47,14 +47,17 @@ Quay.IO will automatically build images for tagged commits, so they can be deplo
 ### Releasing to staging and prod
 1. Coordinate with wranglers who may be using the server
     - Give a heads up during stand up meeting.
-2. Update changelog.
+2. Copy the `staging` deployment to `production` by copying respective staging environment image tags to production.
+3. Update changelog.
+    - Copy the staging changelog from since the last production release date and merge changelog entries for the various components
     - If we have some extra instructions for deployment, we could note it in the changelog (not really sure where to put this).
-3. Deploy tagged master branch
-4. Check for failed end-to-end tests
-5. Wrangler acceptance testing
-6. For production release, add version tag dYYYY-MM-DD.<release-count> (e.g. d2020-03-08.1).
+4. Deploy the new production deployment configuration
+5. Check for failed end-to-end tests
+6. Wrangler acceptance testing
+7. For production release, add version tag dYYYY-MM-DD.<release-count> (e.g. d2020-03-08.1) in quay.io.
     - If there were 2 releases for that day, the second tag will be d2020-03-08.2
-7. Send message to AIT channel #hca when
+    - (Optional) Comment inline these version tag in the production deployment configuration
+8. Send message to AIT channel #hca when
     - release is starting
     - release is completed + release notes
 

--- a/docs/Ingest-Release-SOP.md
+++ b/docs/Ingest-Release-SOP.md
@@ -47,17 +47,17 @@ Quay.IO will automatically build images for tagged commits, so they can be deplo
 ### Releasing to staging and prod
 1. Coordinate with wranglers who may be using the server
     - Give a heads up during stand up meeting.
-2. Copy the `staging` deployment to `production` by copying respective staging environment image tags to production.
-3. Update changelog.
+1. Copy the `staging` deployment to `production` by copying respective staging environment image tags to production.
+1. Update changelog.
     - Copy the staging changelog from since the last production release date and merge changelog entries for the various components
     - If we have some extra instructions for deployment, we could note it in the changelog (not really sure where to put this).
-4. Deploy the new production deployment configuration
-5. Check for failed end-to-end tests
-6. Wrangler acceptance testing
-7. For production release, add version tag dYYYY-MM-DD.<release-count> (e.g. d2020-03-08.1) in quay.io.
+1. Deploy the new production deployment configuration
+1. Check for failed end-to-end tests
+1. Wrangler acceptance testing
+1. For production release, add version tag dYYYY-MM-DD.<release-count> (e.g. d2020-03-08.1) in quay.io.
     - If there were 2 releases for that day, the second tag will be d2020-03-08.2
     - (Optional) Comment inline these version tag in the production deployment configuration
-8. Send message to AIT channel #hca when
+1. Send message to AIT channel #hca when
     - release is starting
     - release is completed + release notes
 
@@ -69,10 +69,10 @@ Quay.IO will automatically build images for tagged commits, so they can be deplo
 
 ### Releasing hotfixes
 1. Inform the team of the hotfix. Team will decide if hotfix is needed and safe.
-2. Branch from the commit hash currently deployed in staging.
-3. Tag the commit. Deploy to staging. All tests must passed (DCP tests in staging, ingest tests, unit tests)
-5. Make a hotfix release notes
-7. Deploy to prod. Make sure all tests passed after hotfix release.
+1. Branch from the commit hash currently deployed in staging.
+1. Tag the commit. Deploy to staging. All tests must passed (DCP tests in staging, ingest tests, unit tests)
+1. Make a hotfix release notes
+1. Deploy to prod. Make sure all tests passed after hotfix release.
 
 ### Links
 - [Ingest Integration Tests](https://gitlab.ebi.ac.uk/hca/ingest-integration-tests)


### PR DESCRIPTION
Addresses some staging -> prod difficulties I encountered

1. We should use commit hash image tags all the way up to production. This allows a staging->prod release to be as simple as copying the staging deployment configuration into the production deployment configuration. Otherwise, it's not straightforward to diff the existing prod release from the prod release to-be, which is necessary for generating accurate changelogs. If we squashed our commits for features/bugfixes then this change would also make it trivial to [generate automated changelogs from the commit history](https://medium.com/jobtome-engineering/how-to-generate-changelog-using-conventional-commits-10be40f5826c)
2. Date tags are still accounted for as comments in the production deployment configuration